### PR TITLE
Rename Template to React Starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# React-TypeScript Starter
+# React Starter
 
-Kickstart your [React](https://react.dev/) project with [TypeScript](https://www.typescriptlang.org/) using this minimalistic [GitHub repository template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template).
+A minimalistic template for starting a new [React](https://react.dev/) project.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
-  "name": "starter",
+  "name": "my_app",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "starter",
-      "version": "0.1.0",
+      "name": "my_app",
       "dependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
-  "name": "starter",
+  "name": "my_app",
   "private": true,
-  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: "/react-ts-starter",
+  base: "/react-starter",
   plugins: [react()],
 })


### PR DESCRIPTION
This pull request resolves #21 by renaming the template to React Starter. In doing so, it also modifies the sample package to `my_app`.