### PR TITLE
Fix Lefthook Configuration Not Checking `.tsx` Files

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,7 +18,7 @@ pre-commit:
     - name: check types
       run: pnpm tsc --noEmit
       glob:
-        - "*.ts"
+        - "*.{ts,tsx}"
         - .npmrc
         - pnpm-lock.yaml
         - tsconfig.json


### PR DESCRIPTION
This pull request resolves #444 by modifying the Lefthook configuration in the `lefthook.yml` file to check for `.tsx` files during the check types step.