### PR TITLE
Remove Glob Pattern for Filtering Lefthook Jobs

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -14,4 +14,4 @@ pre-commit:
       run: pnpm eslint --fix
 
     - name: check diff
-      run: git diff --exit-code {staged_files}
+      run: git diff --exit-code pnpm-lock.yaml {staged_files}

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -8,10 +8,10 @@ pre-commit:
       run: pnpm tsc
 
     - name: fix formatting
-      run: pnpm prettier --write --ignore-unknown {staged_files}
+      run: pnpm prettier --write .
 
     - name: fix lint
-      run: pnpm eslint --no-warn-ignored --fix {staged_files}
+      run: pnpm eslint --fix
 
     - name: check diff
       run: git diff --exit-code {staged_files}

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -3,19 +3,9 @@ pre-commit:
   jobs:
     - name: install dependencies
       run: pnpm install
-      glob:
-        - .npmrc
-        - package.json
-        - pnpm-lock.yaml
-        - pnpm-workspace.yaml
 
     - name: check types
       run: pnpm tsc
-      glob:
-        - "*.{ts,tsx}"
-        - .npmrc
-        - pnpm-lock.yaml
-        - tsconfig.json
 
     - name: fix formatting
       run: pnpm prettier --write --ignore-unknown {staged_files}


### PR DESCRIPTION
This pull request resolves #490 by removing the glob pattern used to filter Lefthook jobs. It also modifies jobs to process all files, adds the `pnpm-lock.yaml` file to the list of files checked for changes, and rename the Lefthook configuration file to `lefthook.yaml`.