### PR TITLE
Make `.gitignore` rules for dot-prefixed files more specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .*
-!.git*
-!.prettier*
+!.github/
+!.gitattributes
+!.gitignore
+!.prettierignore
+!.prettierrc.json
 
 dist/
 node_modules/


### PR DESCRIPTION
This pull request resolves #670 by making the rules for including dot-prefixed files in `.gitignore` more specific.