### PR TITLE
Fix stray lefthook entry in pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,2 @@
 allowBuilds:
   esbuild: true
-  lefthook: set this to true or false


### PR DESCRIPTION
## Summary

- #673 removed `lefthook` from `devDependencies`, but instead of removing its corresponding entry in `allowBuilds`, it left a stray/corrupted line (`lefthook: set this to true or false`) in `pnpm-workspace.yaml`. This fixes it by removing that leftover entry, since `lefthook` is no longer a dependency.