### PR TITLE
Remove redundant `dev` and `test` scripts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
         run: pnpm tsc
 
       - name: Test App
-        run: pnpm test
+        run: pnpm vitest run
 
       - name: Check Formatting
         run: pnpm prettier --check .

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For more information on pnpm, including how to add dependencies or run tools, re
 Run the development version of the app using:
 
 ```sh
-pnpm dev
+pnpm vite
 ```
 
 While viewing the development version, you can modify the app by updating the source code in the [`src`](./src) directory. You can also modify the [`index.html`](./index.html) file to update the app’s metadata, such as the title and icon. If you're new to [React](https://react.dev/), refer to [this documentation](https://react.dev/learn) for guidance.
@@ -56,7 +56,7 @@ Test files in this template are named `*.test.tsx` and typically correspond to t
 After writing the tests, run them with:
 
 ```sh
-pnpm test
+pnpm vitest run
 ```
 
 ### Deploying the App

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "prepare": "playwright install chromium --only-shell",
-    "test": "vitest run"
+    "prepare": "playwright install chromium --only-shell"
   },
   "dependencies": {
     "react": "^19.2.8",


### PR DESCRIPTION
This pull request resolves #682 by removing redundant `dev` and `test` scripts from the `package.json`.