### PR TITLE
Update GitHub Actions workflow, job, and step naming

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,34 +1,34 @@
-name: Build
+name: CI
 on:
   workflow_dispatch:
   pull_request:
   push:
     branches: [main]
 jobs:
-  build-app:
-    name: Build App
+  build:
+    name: Build
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout Project
+      - name: Checkout
         uses: actions/checkout@v7.0.1
 
       - name: Setup pnpm
         uses: threeal/setup-pnpm-action@v2.0.0
 
-      - name: Install Dependencies
+      - name: Install dependencies
         run: pnpm install
 
-      - name: Check Types
+      - name: Check types
         run: pnpm tsc
 
-      - name: Test App
+      - name: Test
         run: pnpm vitest run
 
-      - name: Check Formatting
+      - name: Check formatting
         run: pnpm prettier --check .
 
-      - name: Check Lint
+      - name: Check lint
         run: pnpm eslint
 
-      - name: Build App
+      - name: Build
         run: pnpm vite build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,36 +4,36 @@ on:
   push:
     branches: [main]
 jobs:
-  deploy-app:
-    name: Deploy App
+  deploy-pages:
+    name: Deploy Pages
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
       pages: write
     environment:
       name: github-pages
-      url: ${{ steps.deploy-app.outputs.page_url }}
+      url: ${{ steps.deploy-pages.outputs.page_url }}
     concurrency:
       group: pages
       cancel-in-progress: true
     steps:
-      - name: Checkout Project
+      - name: Checkout
         uses: actions/checkout@v7.0.1
 
       - name: Setup pnpm
         uses: threeal/setup-pnpm-action@v2.0.0
 
-      - name: Install Dependencies
+      - name: Install dependencies
         run: pnpm install
 
-      - name: Build App
+      - name: Build
         run: pnpm vite build
 
-      - name: Upload App
+      - name: Upload pages
         uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: dist
 
-      - name: Deploy App
-        id: deploy-app
+      - name: Deploy pages
+        id: deploy-pages
         uses: actions/deploy-pages@v5.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Linter configured in `eslint.config.ts`.
 
 Automates CI/CD. Workflow files:
 
-- **`.github/workflows/build.yaml`** — Triggers on push to `main`, pull requests, and manual dispatch. Type-checks, tests, checks formatting and lint, and builds the app.
+- **`.github/workflows/ci.yaml`** — Triggers on push to `main`, pull requests, and manual dispatch. Type-checks, tests, checks formatting and lint, and builds the app.
 - **`.github/workflows/deploy.yaml`** — Triggers on push to `main` and manual dispatch. Builds the app and deploys it to GitHub Pages.
 
 ### Lefthook
@@ -73,7 +73,7 @@ lefthook run pre-commit --all-files  # all files
 
 If any file changes during the run, re-stage the changed files and retry.
 
-CI (`.github/workflows/build.yaml`) doesn't invoke Lefthook — it runs `pnpm tsc`, `pnpm vitest run`, `pnpm prettier --check .`, `pnpm eslint`, and `pnpm vite build` as separate steps instead.
+CI (`.github/workflows/ci.yaml`) doesn't invoke Lefthook — it runs `pnpm tsc`, `pnpm vitest run`, `pnpm prettier --check .`, `pnpm eslint`, and `pnpm vite build` as separate steps instead.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

- Rename `build.yaml` to `ci.yaml` and update workflow name from `Build` to `CI`
- Rename job `build-app` / `Build App` to `build` / `Build`
- Rename job `deploy-app` / `Deploy App` to `deploy-pages` / `Deploy Pages` (matches the specific deploy target, consistent with `threeal/threeal`'s equivalent workflow)
- Update step names to sentence case, dropping the redundant self-referential `App`/`Project` noun where a step's responsibility is otherwise unambiguous (e.g. `Checkout Project` → `Checkout`, `Test App` → `Test`, `Install Dependencies` → `Install dependencies`)
- Update `CLAUDE.md` to reference the renamed `ci.yaml` workflow file

Follows the same convention adopted in:
- threeal/threeal#159
- threeal/nodejs-starter#1081
- threeal/action-starter#947

Closes #692