### PR TITLE
Update CI to validate pre-commit hook

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,23 +12,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7.0.1
 
+      - name: Setup Lefthook
+        uses: threeal/setup-lefthook-action@v1.0.0
+
       - name: Setup pnpm
         uses: threeal/setup-pnpm-action@v2.0.0
 
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Check types
-        run: pnpm tsc
+      - name: Check pre-commit hook
+        run: lefthook run pre-commit --all-files
 
       - name: Test
         run: pnpm vitest run
-
-      - name: Check formatting
-        run: pnpm prettier --check .
-
-      - name: Check lint
-        run: pnpm eslint
 
       - name: Build
         run: pnpm vite build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Linter configured in `eslint.config.ts`.
 
 Automates CI/CD. Workflow files:
 
-- **`.github/workflows/ci.yaml`** — Triggers on push to `main`, pull requests, and manual dispatch. Type-checks, tests, checks formatting and lint, and builds the app.
+- **`.github/workflows/ci.yaml`** — Triggers on push to `main`, pull requests, and manual dispatch. Validates the pre-commit hook, tests, and builds the app.
 - **`.github/workflows/deploy.yaml`** — Triggers on push to `main` and manual dispatch. Builds the app and deploys it to GitHub Pages.
 
 ### Lefthook
@@ -68,12 +68,12 @@ Run the pre-commit hook to check types, formatting, and lint locally:
 
 ```sh
 lefthook run pre-commit              # staged files only (default)
-lefthook run pre-commit --all-files  # all files
+lefthook run pre-commit --all-files  # all files — matches what CI runs
 ```
 
 If any file changes during the run, re-stage the changed files and retry.
 
-CI (`.github/workflows/ci.yaml`) doesn't invoke Lefthook — it runs `pnpm tsc`, `pnpm vitest run`, `pnpm prettier --check .`, `pnpm eslint`, and `pnpm vite build` as separate steps instead.
+CI (`.github/workflows/ci.yaml`) runs `lefthook run pre-commit --all-files` to validate the pre-commit hook, then runs `pnpm vitest run` and `pnpm vite build` as separate steps.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This template provides a basic React project containing a sample web application
 - Uses [pnpm](https://pnpm.io/) as the package manager.
 - Supports formatting with [Prettier](https://prettier.io/), linting with [ESLint](https://eslint.org/), and testing with [Vitest](https://vitest.dev/).
 - Fixes formatting and linting during pre-commit hooks using [Lefthook](https://lefthook.dev/).
-- Preconfigured workflows for [Dependabot](https://docs.github.com/en/code-security/dependabot) and [GitHub Actions](https://github.com/features/actions).
+- Preconfigured [Dependabot](https://docs.github.com/en/code-security/dependabot) and [GitHub Actions](https://github.com/features/actions) workflows that validate the pre-commit hook.
 - Supports deployment of the web application to [GitHub Pages](https://pages.github.com/).
 
 ## Usage


### PR DESCRIPTION
Resolves #694.

## Summary

- Replaces individual CI check steps (install deps, type-check, format, lint) with Lefthook setup + `lefthook run pre-commit --all-files`
- Updates `README.md` and `CLAUDE.md` to reflect that CI now validates the pre-commit hook instead of running each check separately

Follows the same convention adopted in [`nodejs-starter`](https://github.com/threeal/nodejs-starter/blob/main/.github/workflows/ci.yaml).