### PR TITLE
Align README and CLAUDE.md with sibling starter templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,6 @@ lefthook run pre-commit --all-files  # all files — matches what CI runs
 
 If any file changes during the run, re-stage the changed files and retry.
 
-CI (`.github/workflows/ci.yaml`) runs `lefthook run pre-commit --all-files` to validate the pre-commit hook, then runs `pnpm vitest run` and `pnpm vite build` as separate steps.
-
 ## Testing
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,64 +1,63 @@
 # React Starter
 
-A minimalist template for starting a new [React](https://react.dev/) project.
+A minimal template for building a [React](https://react.dev/) app in [TypeScript](https://www.typescriptlang.org/), bundled with [Vite](https://vite.dev/). Ships pre-configured with formatting, linting, 100% test coverage enforcement, pre-commit hooks, and CI/CD.
 
-This template provides a basic React project containing a sample web application written in [TypeScript](https://www.typescriptlang.org/), with built-in support for formatting, linting, testing, and continuous integration.
+## Getting Started
 
-## Key Features
+Create a new repository from this template on GitHub using [this link](https://github.com/new?template_name=react-starter&template_owner=threeal), or clone it locally and point it at your own remote.
 
-- Minimal React project written in TypeScript with [ESM](https://nodejs.org/api/esm.html) support.
-- Uses [pnpm](https://pnpm.io/) as the package manager.
-- Supports formatting with [Prettier](https://prettier.io/), linting with [ESLint](https://eslint.org/), and testing with [Vitest](https://vitest.dev/).
-- Fixes formatting and linting during pre-commit hooks using [Lefthook](https://lefthook.dev/).
-- Preconfigured [Dependabot](https://docs.github.com/en/code-security/dependabot) and [GitHub Actions](https://github.com/features/actions) workflows that validate the pre-commit hook.
-- Supports deployment of the web application to [GitHub Pages](https://pages.github.com/).
+## Setup
 
-## Usage
-
-This guide explains how to use this template to start a new React project, from creation to deployment.
-
-### Create a New Project
-
-Follow [this link](https://github.com/new?template_name=react-starter&template_owner=threeal) to create a new project based on this template. For more information about creating a repository from a template on GitHub, refer to [this documentation](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template).
-
-Alternatively, you can clone this repository locally to begin using this template.
-
-### Choose a License
-
-By default, this template is [unlicensed](https://unlicense.org/). Before modifying this template, it is recommended to replace the [`LICENSE`](./LICENSE) file with the license that will be used for the new project. For more information about licensing a repository, refer to [this documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository).
-
-Alternatively, you can remove the `LICENSE` file or leave it as is to keep the new project unlicensed.
-
-### Set Up Tools
-
-This template uses [pnpm](https://pnpm.io/) as the package manager. If pnpm is not installed, follow [this guide](https://pnpm.io/installation) to install it. Then, install the project dependencies with:
+Install [pnpm](https://pnpm.io/), then install dependencies:
 
 ```sh
 pnpm install
 ```
 
-For more information on pnpm, including how to add dependencies or run tools, refer to [this documentation](https://pnpm.io/pnpm-cli).
+Install [Lefthook](https://lefthook.dev/), then register the pre-commit hook:
 
-### Developing the App
+```sh
+lefthook install
+```
 
-Run the development version of the app using:
+## Customizing
+
+Replace or extend the template files to fit your project:
+
+- **`src/App.tsx`** — Replace with your actual application UI.
+- **`index.html`** — Update the page title, icon, and other metadata.
+- **`CLAUDE.md`** — Replace with guidance specific to your project.
+- **`LICENSE`** — Replace with your preferred license, or keep the [Unlicense](https://unlicense.org/).
+- **`README.md`** — Replace with a description of your project.
+
+## Development
+
+Write code in `src/`. Try the app locally in development mode with:
 
 ```sh
 pnpm vite
 ```
 
-While viewing the development version, you can modify the app by updating the source code in the [`src`](./src) directory. You can also modify the [`index.html`](./index.html) file to update the app’s metadata, such as the title and icon. If you're new to [React](https://react.dev/), refer to [this documentation](https://react.dev/learn) for guidance.
+This supports hot reload, so changes to the source code are reflected directly in the running app.
 
-### Testing the App
-
-Test files in this template are named `*.test.tsx` and typically correspond to the components being tested. This template uses [Vitest](https://vitest.dev/) and [Playwright](https://playwright.dev/) for testing. For more information on testing with Vitest, refer to [this documentation](https://vitest.dev/guide/).
-
-After writing the tests, run them with:
+Test files live alongside source as `*.test.tsx`. Run the test suite with:
 
 ```sh
 pnpm vitest run
 ```
 
-### Deploying the App
+The project enforces 100% code coverage on every run.
 
-To deploy the app, first set up your GitHub repository to enable deployment to GitHub Pages using GitHub Actions (see [this guide](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow)). Then commit your changes and push them to the `main` branch. Every change pushed to the `main` branch will automatically trigger a CI workflow to deploy the app to GitHub Pages.
+Before committing, run the pre-commit hook to install dependencies, type-check, and fix formatting and lint:
+
+```sh
+lefthook run pre-commit
+```
+
+If any file changes during the run, re-stage the changed files and retry. The hook also runs automatically on each `git commit` — if it fails, fix the reported issues, re-stage, and commit again.
+
+After committing, push to `main` or open a pull request from another branch — CI will run the pre-commit hook across all files, the full test suite, and `pnpm vite build`.
+
+## Deploying
+
+Set up your GitHub repository to enable deployment to GitHub Pages using GitHub Actions (see [this guide](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow)). Then push to `main` — CI will automatically build the app and deploy it to GitHub Pages.


### PR DESCRIPTION
## Summary

- Rewrite `README.md` to follow the same structure as `nodejs-starter`/`action-starter` (`Getting Started` → `Setup` → `Customizing` → `Development` → deploy section), replacing the previous React-specific layout.
- Document running `pnpm vite` for local development with hot reload in the `Development` section.
- Add a `Deploying` section describing the GitHub Pages setup and continuous deployment on push to `main`.
- Trim a sentence from `CLAUDE.md`'s `Checking and Fixing` section describing what CI runs, since that detail isn't documented in either sibling template's `CLAUDE.md`.