### PR TITLE
Bump pnpm to version 11.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,5 @@
       "onFail": "download"
     }
   },
-  "packageManager": "pnpm@11.21.0"
+  "packageManager": "pnpm@11.22.0"
 }


### PR DESCRIPTION
This pull request bumps pnpm to version [11.22.0](https://github.com/pnpm/pnpm/releases/tag/v11.22.0).